### PR TITLE
chore(release): bump version to 0.15.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.6] - 2026-03-29
+
+### Added
+- `sanitize_filesystem_chars` function to replace invalid characters (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`) in filenames and directory names with safe equivalents
+
+### Changed
+- `Config::format_filename` and `Config::format_directory` now apply filesystem character sanitization to ensure safe output on all platforms
+
+### Fixed
+- Filenames and directory names derived from video titles no longer contain characters that are invalid on Windows/Linux/macOS filesystems
+
 ## [0.15.5] - 2026-03-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "youtube_chapter_splitter"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtube_chapter_splitter"
-version = "0.15.5"
+version = "0.15.6"
 edition = "2024"
 authors = ["YouTube Chapter Splitter Contributors"]
 description = "Download YouTube videos, extract audio to MP3, and split by chapters"


### PR DESCRIPTION
- Updated version in Cargo.toml and Cargo.lock to 0.15.6
- Added changelog entry for filesystem character sanitization in filenames and directory names introduced in the previous PR

https://claude.ai/code/session_01Nqchgt8ykzQ1akEcddEUcT